### PR TITLE
Allow specifying frequency lists in ZXCVBNValidator options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,6 +161,28 @@ like this:
 
             return self.cleaned_data
 
+Custom frequency lists
+======================
+zxcvbn-python provides a feature to add custom frequency lists, you can specify your
+own custom frequency lists in the validator by adding frequency_lists to AUTH_PASSWORD_VALIDATORS, where dutch_words
+is a list of strings:
+
+.. code:: python
+
+    # settings.py
+
+    AUTH_PASSWORD_VALIDATORS = [
+        ...
+        {
+            'NAME': 'zxcvbn_password.ZXCVBNValidator',
+            'OPTIONS': {
+                'frequency_lists': {
+                    'dutch': dutch_words,
+                }
+            }
+        }
+    ]
+
 
 Screen-shot
 ===========

--- a/src/zxcvbn_password/validators.py
+++ b/src/zxcvbn_password/validators.py
@@ -22,7 +22,7 @@ class ZXCVBNValidator(object):
 
     def __init__(self, min_score=DEFAULT_MIN_SCORE,
                  user_attributes=DEFAULT_USER_ATTRIBUTES,
-                 frequency_lists={}):
+                 frequency_lists=None):
         """
         Init method.
 
@@ -34,9 +34,10 @@ class ZXCVBNValidator(object):
             min_score = 1
         elif min_score > 4:
             min_score = 4
+
         self.min_score = min_score
         self.user_attributes = user_attributes
-        self.frequency_lists = frequency_lists
+        self.frequency_lists = frequency_lists or {}
 
     def __call__(self, value):
         """Call method, run self.validate (can be used in form fields)."""

--- a/src/zxcvbn_password/validators.py
+++ b/src/zxcvbn_password/validators.py
@@ -8,6 +8,7 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 
 from zxcvbn import zxcvbn
+from zxcvbn.matching import add_frequency_lists
 
 
 DEFAULT_MIN_SCORE = 3
@@ -20,7 +21,8 @@ class ZXCVBNValidator(object):
     DEFAULT_USER_ATTRIBUTES = ('username', 'first_name', 'last_name', 'email')
 
     def __init__(self, min_score=DEFAULT_MIN_SCORE,
-                 user_attributes=DEFAULT_USER_ATTRIBUTES):
+                 user_attributes=DEFAULT_USER_ATTRIBUTES,
+                 frequency_lists={}):
         """
         Init method.
 
@@ -34,6 +36,7 @@ class ZXCVBNValidator(object):
             min_score = 4
         self.min_score = min_score
         self.user_attributes = user_attributes
+        self.frequency_lists = frequency_lists
 
     def __call__(self, value):
         """Call method, run self.validate (can be used in form fields)."""
@@ -46,6 +49,8 @@ class ZXCVBNValidator(object):
             for attribute in self.user_attributes:
                 if hasattr(user, attribute):
                     user_inputs.append(getattr(user, attribute))
+
+        add_frequency_lists(self.frequency_lists)
 
         results = zxcvbn(password, user_inputs=user_inputs)
         if results.get('score', 0) < self.min_score:


### PR DESCRIPTION
This PR allows specifying frequency_lists in the ZXCVBNValidator options by adding a dict in the following form:

        {
            'NAME': 'pages.validators.CustomZXCVBNValidator',
            'OPTIONS': {
                'min_score': 3,
                'frequency_lists': {
                    'dutch': dutch_words,
                }
            }
        }